### PR TITLE
implement time to live

### DIFF
--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\React\Cache;
+
+/**
+ * one item in a cache. Only used locally within the cache
+ */
+class CacheItem
+{
+    /** @var mixed the data to be cached */
+    private $data;
+
+    /** @var float|null */
+    private $expiresAt;
+
+    /**
+     * @param mixed $data
+     * @param float|null $expiresAtTime
+     */
+    public function __construct($data, float $expiresAtTime = null)
+    {
+        $this->data      = $data;
+        $this->expiresAt = $expiresAtTime;
+    }
+
+    public function getExpiresAt(): ?float
+    {
+        return $this->expiresAt;
+    }
+
+    /**
+     * @param float|null $now current time
+     * @return bool
+     */
+    public function hasExpired(float $now = null): bool
+    {
+        return is_null($this->expiresAt) ? false : $now > $this->expiresAt;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/tests/CacheItemTest.php
+++ b/tests/CacheItemTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace WyriHaximus\Tests\React\Cache;
+
+use WyriHaximus\React\Cache\CacheItem;
+
+/**
+ * @internal
+ */
+class CacheItemTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConstructor()
+    {
+        $time    = 123456;
+        $subject = new CacheItem($data = ['abc' => 123], $time);
+        self::assertEquals($data, $subject->getData());
+        self::assertEquals($time, $subject->getExpiresAt());
+
+        self::assertTrue($subject->hasExpired($time + 1));
+        self::assertFalse($subject->hasExpired($time));
+        self::assertFalse($subject->hasExpired($time - 1));
+    }
+}


### PR DESCRIPTION
see #24 

- many tests broken because they test implementation details (the contents of the file on disk). Would it make sense to just test behaviour (the `CacheInterface`)?
- i copied `Filesystem::now()` from `ArrayCache::now()`. If `now()` was protected, maybe we could make a `FakeFilesystem` to override `now()` with a value we control for testing purposes... except that the `Filesystem` class is final...
- this change makes existing caches on disk incompatible: so if you release it needs to be a new major version?
- maybe need a `clean()` method which would look for all files on disk, read them all, then delete the expired ones
